### PR TITLE
Fix typo in ALU.cpp

### DIFF
--- a/tinyram/stark-tinyram/src/TinyRAMtoBair/RamToContraintSystem/ALU.cpp
+++ b/tinyram/stark-tinyram/src/TinyRAMtoBair/RamToContraintSystem/ALU.cpp
@@ -132,7 +132,7 @@ void ALU_Gadget::createInternalComponents() {
 		resultVariables_);
 	components_[Opcode::UDIV] = ALU_UDIV_Gadget::create(pb_, inputVariables_,
 															resultVariables_);
-	components_[Opcode::UMOD] = ALU_UDIV_Gadget::create(pb_, inputVariables_,
+	components_[Opcode::UMOD] = ALU_UMOD_Gadget::create(pb_, inputVariables_,
 															resultVariables_);
 	components_[Opcode::CMPE] = ALU_CMPE_Gadget::create(pb_, inputVariables_,
 															resultVariables_);


### PR DESCRIPTION
As stated in #15 `UMOD` seems to be broken.

There has been a typo in ALU.cpp and it was
```
components_[Opcode::UMOD] = ALU_UDIV_Gadget::create(pb_, inputVariables_, resultVariables_);
```
instead of 
```
components_[Opcode::UMOD] = ALU_UMOD_Gadget::create(pb_, inputVariables_, resultVariables_);
```
That was probably a problem with `UMOD`, however it still seems to be broken.
