### PR TITLE
Building in OSX. Support both for gcc-c++ and clang++ (with openMP)

### DIFF
--- a/algebra/FFT/Makefile
+++ b/algebra/FFT/Makefile
@@ -12,6 +12,10 @@ TARGET=$(BLDDIR)/libFFT.a
 SRCS:= $(shell ls src/*.cpp)
 OBJS=$(addprefix $(BLDDIR)/, $(SRCS:.cpp=.o))
 
+ifeq ($(AR),)
+AR = ar -r
+endif
+
 $(BLDDIR)/%.o: %.cpp
 #	@echo 'Building file: $@ ($<)'
 	@$(MKDIR) -p $(shell $(DIRNAME) $@)
@@ -24,4 +28,5 @@ clean:
 
 $(TARGET): $(OBJS)
 #	@echo 'Building target: $@'
-	ar -r  "$@" $(OBJS) $(LIBS)
+	echo AR=$(AR)
+	$(AR) "$@" $(OBJS) $(LIBS)

--- a/algebra/algebralib-tests/Makefile
+++ b/algebra/algebralib-tests/Makefile
@@ -35,5 +35,5 @@ clean:
 $(TARGET): $(OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GCC Linker'
-	$(CC) -o "$@" $(OBJS) -fopenmp $(LNKFLAGS) $(LIBFLAGS)
+	$(CC) -o "$@" $(OBJS) -fopenmp $(LNKFLAGS) $(LIBFLAGS) $(CFLAGS) $(LDFLAGS)
 	@echo 'Finished building target: $@'

--- a/algebra/algebralib-tests/Makefile
+++ b/algebra/algebralib-tests/Makefile
@@ -35,5 +35,5 @@ clean:
 $(TARGET): $(OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GCC Linker'
-	$(CC) -o "$@" $(OBJS) -fopenmp $(LNKFLAGS) $(LIBFLAGS) $(CFLAGS) $(LDFLAGS)
+	$(CC) -o "$@" $(OBJS) $(LNKFLAGS) $(LIBFLAGS) $(CFLAGS) $(LDFLAGS)
 	@echo 'Finished building target: $@'

--- a/algebra/algebralib/Makefile
+++ b/algebra/algebralib/Makefile
@@ -12,6 +12,10 @@ TARGET=$(BLDDIR)/libalgebralib.a
 SRCS:= $(shell ls src/*.cpp)
 OBJS=$(addprefix $(BLDDIR)/, $(SRCS:.cpp=.o))
 
+ifeq ($(AR),)
+AR = ar -r
+endif
+
 $(BLDDIR)/%.o: %.cpp
 #	@echo 'Building file: $@ ($<)'
 	@$(MKDIR) -p $(shell $(DIRNAME) $@)
@@ -24,4 +28,4 @@ clean:
 
 $(TARGET): $(OBJS)
 #	@echo 'Building target: $@'
-	ar -r  "$@" $(OBJS)
+	$(AR) "$@" $(OBJS)

--- a/algebra/algebralib/src/ErrorHandling.cpp
+++ b/algebra/algebralib/src/ErrorHandling.cpp
@@ -16,11 +16,12 @@ Common functionality needed by many components.
 #include "algebraLib/ErrorHandling.hpp"
 
 
-#ifdef __linux__
+#ifndef WIN32
 #include <unistd.h>
 #include <cstdio>
 #endif
-#ifdef __GLIBC__
+
+#if defined(__GLIBC__) || defined(__APPLE__)
 #include <execinfo.h> // backtraces
 #endif
 

--- a/flags.mk
+++ b/flags.mk
@@ -1,3 +1,48 @@
-CC=g++
-CPPFLAGS=-std=c++11
-CFLAGS=-O3 -g -Wall -fmessage-length=0 -fopenmp -maes -msse4 -mtune=native
+OSFLAG 				:=
+
+# In current buildsystem CC is confused with CXX, 
+# to have next part of this file works, its needed
+# to override CC with CXX environment variable
+CC=$(CXX)
+
+ifeq ($(OS),Windows_NT)
+	# TODO
+else
+	LDFLAGS += -L /usr/local/lib
+	 CFLAGS += -I /usr/local/include
+ 
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Linux)
+		# Use default system-wide g++ if CC is not defined
+		ifeq ($(CC),)
+			CC=/usr/bin/g++
+		endif
+
+		AR=/usr/bin/ar crv
+	endif
+	
+	ifeq ($(UNAME_S),Darwin)
+		# Use g++ provided by Homebrew
+		# brew install gcc-c++ v8
+		ifeq ($(CC),)
+			CC=/usr/local/bin/g++-8
+		endif
+		# XCode libtool instead of gnu ar
+		AR=libtool -static -a -o
+	endif
+
+ 	# Currently openmp is part of gcc:
+	ifeq ($(shell $(CC) -v 2>&1 | grep -c "gcc version"), 1)
+		CFLAGS += -fopenmp
+	endif
+
+	# But openmp could be linked while used clang as well
+	# Homebrew: brew install libomp 
+	ifeq ($(shell $(CC) -v 2>&1 | grep -c "clang version"), 1)
+		CFLAGS += "-fopenmp=libomp"
+	endif
+endif
+
+CPPFLAGS += -std=c++11
+CFLAGS += -O3 -g -Wall -fmessage-length=0 -maes -msse4 -mtune=native
+

--- a/libstark/Makefile
+++ b/libstark/Makefile
@@ -10,13 +10,17 @@ SRCS    := $(shell find $(SRCDIR) -name '*.$(SRCEXT)')
 SRCDIRS := $(shell find . -name '*.$(SRCEXT)' -exec dirname {} \; | uniq)
 OBJS    := $(patsubst %.$(SRCEXT),$(OBJDIR)/%.o,$(SRCS))
 
+ifeq ($(AR),)
+AR = ar -r
+endif
+
 TARGET=$(BLDDIR)/libstark.a
 all: $(TARGET)
 
 $(TARGET): buildrepo $(OBJS)
 #	@echo 'Building target: $@'
 #	@echo 'Invoking: GCC Linker'
-	ar -r  "$@" $(OBJS) $(LIBS)
+	$(AR)  "$@" $(OBJS) $(LIBS)
 #	@echo 'Finished building target: $@'
 
 $(OBJDIR)/%.o: %.$(SRCEXT)

--- a/libstark/src/common/Utils/ErrorHandling.hpp
+++ b/libstark/src/common/Utils/ErrorHandling.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <sstream>
 
-#ifdef __GLIBC__
+#ifndef WIN32
 #include <execinfo.h> // backtraces
 #endif
 

--- a/starkdpm/Makefile
+++ b/starkdpm/Makefile
@@ -28,7 +28,7 @@ all: $(TARGET)
 $(TARGET): buildrepo $(OBJS)
 #	@echo 'Building target: $@'
 #	@echo 'Invoking: GCC Linker'
-	$(CC) -o "$@" $(OBJS) -fopenmp $(LNKFLAGS) $(LIBFLAGS)
+	$(CC) -o "$@" $(OBJS) $(CFLAGS) $(LNKFLAGS) $(LIBFLAGS)
 #	@echo 'Finished building target: $@'
 	cp $(TARGET) $(DST)
 

--- a/tinyram/gadgetlib/gadgetlib/Makefile
+++ b/tinyram/gadgetlib/gadgetlib/Makefile
@@ -20,6 +20,10 @@ SRCS=					\
 
 OBJS=$(addprefix $(BLDDIR)/, $(SRCS:.cpp=.o))
 
+ifeq ($(AR),)
+AR = ar -r
+endif
+
 $(BLDDIR)/%.o: %.cpp
 #	@echo 'Building file: $@ ($<)'
 	@$(MKDIR) -p $(shell $(DIRNAME) $@)
@@ -33,6 +37,6 @@ clean:
 $(TARGET): $(OBJS)
 #	@echo 'Building target: $@'
 #	@echo 'Invoking: GCC Archiver'
-	ar -r  "$@" $(OBJS) $(LIBS)
+	$(AR)  "$@" $(OBJS) $(LIBS)
 #	@echo 'Finished building target: $@'
 #	@echo ' '

--- a/tinyram/gadgetlib/gadgetlib/infrastructure.cpp
+++ b/tinyram/gadgetlib/gadgetlib/infrastructure.cpp
@@ -13,11 +13,10 @@ Common functionality needed by many components.
 #include <cassert>
 #include <stdexcept>
 #include <climits>
-#ifdef __linux__
+
+#ifndef WIN32
 #include <unistd.h>
 #include <cstdio>
-#endif
-#ifdef __GLIBC__
 #include <execinfo.h> // backtraces
 #endif
 

--- a/tinyram/stark-tinyram-tests/Makefile
+++ b/tinyram/stark-tinyram-tests/Makefile
@@ -25,13 +25,13 @@ all: $(TARGET)
 $(TARGET): $(OBJS)
 #	@echo 'Building target: $@'
 #	@echo 'Invoking: GCC Linker'
-	$(CC) -o "$@" $(OBJS) $(TINYRAMOBJS) -fopenmp $(LNKFLAGS) $(LIBFLAGS)
+	$(CC) -o "$@" $(OBJS) $(TINYRAMOBJS) -fopenmp $(LNKFLAGS) $(LIBFLAGS) $(LDFLAGS) 
 #	@echo 'Finished building target: $@'
 
 $(BLDDIR)/%.o: %.cpp
 #	@echo 'Building file: $@ ($<)'
 	@$(MKDIR) -p $(shell $(DIRNAME) $@)
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(INCFLAGS) -c -o "$@" "$<"
+	$(CC) $(CFLAGS) $(LDFLAGS) $(CPPFLAGS) $(INCFLAGS) -c -o "$@" "$<"
 
 clean:
 	rm -f $(TARGET) $(OBJS) $(DEPS)

--- a/tinyram/stark-tinyram-tests/Makefile
+++ b/tinyram/stark-tinyram-tests/Makefile
@@ -25,7 +25,7 @@ all: $(TARGET)
 $(TARGET): $(OBJS)
 #	@echo 'Building target: $@'
 #	@echo 'Invoking: GCC Linker'
-	$(CC) -o "$@" $(OBJS) $(TINYRAMOBJS) -fopenmp $(LNKFLAGS) $(LIBFLAGS) $(LDFLAGS) 
+	$(CC) -o "$@" $(OBJS) $(TINYRAMOBJS) $(CFLAGS) $(LNKFLAGS) $(LIBFLAGS) $(LDFLAGS) 
 #	@echo 'Finished building target: $@'
 
 $(BLDDIR)/%.o: %.cpp

--- a/tinyram/stark-tinyram/Makefile
+++ b/tinyram/stark-tinyram/Makefile
@@ -25,7 +25,7 @@ all: $(TARGET)
 $(TARGET): buildrepo $(OBJS)
 #	@echo 'Building target: $@'
 #	@echo 'Invoking: GCC Linker'
-	$(CC) -o "$@" $(OBJS) -fopenmp $(LNKFLAGS) $(LIBFLAGS)
+	$(CC) -o "$@" $(OBJS) $(CFLAGS) $(LNKFLAGS) $(LIBFLAGS)
 #	@echo 'Finished building target: $@'
 	cp $(TARGET) $(DST)
 


### PR DESCRIPTION
Dear Sir,

I want to propose my pull request, that helped to work with your library on my computer (macOS). Probably it will be useful for others.

I did not switched off any parts of your code to be able to compile it under osx and/or clang++, but just found appropriate system call for it.

I did the best I can to check if it still building in Linux. I was able to run all the tests described in README.md with gcc 8.1

Unfortunately, I see some issues while I am trying to compile tests with clang++ or gcc v8.3:
Here the log: [make tests log](https://gist.github.com/mrtuborg/34c561ddd4f72165f4c875eb86119a24)

I think it have sense to fix it in separate pull request to avoid too much work for reviewers.

Faithfully yours,

Vladimir.
